### PR TITLE
Add status badge for project #4001

### DIFF
--- a/server/badge/badge.go
+++ b/server/badge/badge.go
@@ -12,6 +12,7 @@ import (
 
 	appv1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/pkg/client/clientset/versioned"
+	"github.com/argoproj/argo-cd/util/argo"
 	"github.com/argoproj/argo-cd/util/assets"
 	"github.com/argoproj/argo-cd/util/settings"
 )
@@ -85,7 +86,25 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			notFound = true
 		}
 	}
-
+	//Sample url: http://localhost:8080/api/badge?project=default
+	if project, ok := r.URL.Query()["project"]; ok && enabled {
+		if apps, err := h.appClientset.ArgoprojV1alpha1().Applications(h.namespace).List(context.Background(), v1.ListOptions{}); err == nil {
+			for _, a := range argo.FilterByProjects(apps.Items, []string{project[0]}) {
+				if a.Status.Sync.Status != appv1.SyncStatusCodeSynced {
+					status = appv1.SyncStatusCodeOutOfSync
+				}
+				if a.Status.Health.Status != healthutil.HealthStatusHealthy {
+					health = healthutil.HealthStatusDegraded
+				}
+			}
+			if health != healthutil.HealthStatusDegraded {
+				health = healthutil.HealthStatusHealthy
+			}
+			if status != appv1.SyncStatusCodeOutOfSync {
+				status = appv1.SyncStatusCodeSynced
+			}
+		}
+	}
 	//Sample url: http://localhost:8080/api/badge?name=123&revision=true
 	if _, ok := r.URL.Query()["revision"]; ok && enabled {
 		revisionEnabled = true

--- a/server/badge/badge_test.go
+++ b/server/badge/badge_test.go
@@ -50,54 +50,6 @@ var (
 			},
 		},
 	}
-	testApp1 = v1alpha1.Application{
-		ObjectMeta: v1.ObjectMeta{Name: "testApp1", Namespace: "default"},
-		Status: v1alpha1.ApplicationStatus{
-			Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeSynced},
-			Health: v1alpha1.HealthStatus{Status: health.HealthStatusHealthy},
-			OperationState: &v1alpha1.OperationState{
-				SyncResult: &v1alpha1.SyncOperationResult{
-					Revision: "aa29b85",
-				},
-			},
-		},
-	}
-	testApp2 = v1alpha1.Application{
-		ObjectMeta: v1.ObjectMeta{Name: "testApp2", Namespace: "default"},
-		Status: v1alpha1.ApplicationStatus{
-			Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeSynced},
-			Health: v1alpha1.HealthStatus{Status: health.HealthStatusDegraded},
-			OperationState: &v1alpha1.OperationState{
-				SyncResult: &v1alpha1.SyncOperationResult{
-					Revision: "aa29b85",
-				},
-			},
-		},
-	}
-	testApp3 = v1alpha1.Application{
-		ObjectMeta: v1.ObjectMeta{Name: "testApp3", Namespace: "default"},
-		Status: v1alpha1.ApplicationStatus{
-			Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeOutOfSync},
-			Health: v1alpha1.HealthStatus{Status: health.HealthStatusHealthy},
-			OperationState: &v1alpha1.OperationState{
-				SyncResult: &v1alpha1.SyncOperationResult{
-					Revision: "aa29b85",
-				},
-			},
-		},
-	}
-	testApp4 = v1alpha1.Application{
-		ObjectMeta: v1.ObjectMeta{Name: "testApp4", Namespace: "default"},
-		Status: v1alpha1.ApplicationStatus{
-			Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeOutOfSync},
-			Health: v1alpha1.HealthStatus{Status: health.HealthStatusDegraded},
-			OperationState: &v1alpha1.OperationState{
-				SyncResult: &v1alpha1.SyncOperationResult{
-					Revision: "aa29b85",
-				},
-			},
-		},
-	}
 )
 
 func TestHandlerFeatureIsEnabled(t *testing.T) {
@@ -129,10 +81,10 @@ func TestHandlerFeatureProjectIsEnabled(t *testing.T) {
 		healthColor color.RGBA
 		statusColor color.RGBA
 	}{
-		{[]*v1alpha1.Application{&testApp, &testApp1}, "/api/badge?project=default", "default", "Healthy", "Synced", Green, Green},
-		{[]*v1alpha1.Application{&testApp1, &testApp3}, "/api/badge?project=default", "default", "Healthy", "OutOfSync", Green, Orange},
-		{[]*v1alpha1.Application{&testApp1, &testApp2}, "/api/badge?project=default", "default", "Degraded", "Synced", Red, Green},
-		{[]*v1alpha1.Application{&testApp2, &testApp3}, "/api/badge?project=default", "default", "Degraded", "OutOfSync", Red, Orange},
+		{[]*v1alpha1.Application{createApplicationFeatureProjectIsEnabled(health.HealthStatusHealthy, v1alpha1.SyncStatusCodeSynced, "syncHealthy"), createApplicationFeatureProjectIsEnabled(health.HealthStatusHealthy, v1alpha1.SyncStatusCodeSynced, "syncHealthy1")}, "/api/badge?project=default", "default", "Healthy", "Synced", Green, Green},
+		{[]*v1alpha1.Application{createApplicationFeatureProjectIsEnabled(health.HealthStatusHealthy, v1alpha1.SyncStatusCodeSynced, "syncHealthy"), createApplicationFeatureProjectIsEnabled(health.HealthStatusHealthy, v1alpha1.SyncStatusCodeOutOfSync, "outOfsyncHealthy")}, "/api/badge?project=default", "default", "Healthy", "OutOfSync", Green, Orange},
+		{[]*v1alpha1.Application{createApplicationFeatureProjectIsEnabled(health.HealthStatusHealthy, v1alpha1.SyncStatusCodeSynced, "syncHealthy"), createApplicationFeatureProjectIsEnabled(health.HealthStatusDegraded, v1alpha1.SyncStatusCodeSynced, "syncDegraded")}, "/api/badge?project=default", "default", "Degraded", "Synced", Red, Green},
+		{[]*v1alpha1.Application{createApplicationFeatureProjectIsEnabled(health.HealthStatusDegraded, v1alpha1.SyncStatusCodeSynced, "syncDegraded"), createApplicationFeatureProjectIsEnabled(health.HealthStatusDegraded, v1alpha1.SyncStatusCodeOutOfSync, "outOfsyncDegraded")}, "/api/badge?project=default", "default", "Degraded", "OutOfSync", Red, Orange},
 	}
 	for _, tt := range projectTests {
 		settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(&argoCDCm, &argoCDSecret), tt.namespace)
@@ -143,13 +95,26 @@ func TestHandlerFeatureProjectIsEnabled(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 		assert.Equal(t, "private, no-store", rr.Header().Get("Cache-Control"))
 		response := rr.Body.String()
-
 		assert.Equal(t, toRGBString(tt.healthColor), leftRectColorPattern.FindStringSubmatch(response)[1])
 		assert.Equal(t, toRGBString(tt.statusColor), rightRectColorPattern.FindStringSubmatch(response)[1])
 		assert.Equal(t, tt.health, leftTextPattern.FindStringSubmatch(response)[1])
 		assert.Equal(t, tt.status, rightTextPattern.FindStringSubmatch(response)[1])
 
 	}
+}
+
+func createApplicationFeatureProjectIsEnabled(healthStatus health.HealthStatusCode, syncStatus v1alpha1.SyncStatusCode, appName string) *v1alpha1.Application {
+	return &v1alpha1.Application{
+		ObjectMeta: v1.ObjectMeta{Name: appName, Namespace: "default"},
+		Status: v1alpha1.ApplicationStatus{
+			Sync:   v1alpha1.SyncStatus{Status: syncStatus},
+			Health: v1alpha1.HealthStatus{Status: healthStatus},
+			OperationState: &v1alpha1.OperationState{
+				SyncResult: &v1alpha1.SyncOperationResult{},
+			},
+		},
+	}
+
 }
 func TestHandlerFeatureIsEnabledRevisionIsEnabled(t *testing.T) {
 	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(&argoCDCm, &argoCDSecret), "default")

--- a/server/badge/badge_test.go
+++ b/server/badge/badge_test.go
@@ -86,15 +86,24 @@ func TestHandlerFeatureProjectIsEnabled(t *testing.T) {
 		healthColor color.RGBA
 		statusColor color.RGBA
 	}{
-		{createApplications([]string{"Healthy:Synced", "Healthy:Synced"}, []string{"default", "default"}, "test"), "/api/badge?project=default", "test", "Healthy", "Synced", Green, Green},
-		{createApplications([]string{"Healthy:Synced", "Healthy:OutOfSync"}, []string{"testProject", "testProject"}, "default"), "/api/badge?project=testProject", "default", "Healthy", "OutOfSync", Green, Orange},
-		{createApplications([]string{"Healthy:Synced", "Degraded:Synced"}, []string{"default", "default"}, "test"), "/api/badge?project=default", "test", "Degraded", "Synced", Red, Green},
-		{createApplications([]string{"Healthy:Synced", "Degraded:OutOfSync"}, []string{"testProject", "testProject"}, "default"), "/api/badge?project=testProject", "default", "Degraded", "OutOfSync", Red, Orange},
-		{createApplications([]string{"Healthy:Synced", "Healthy:Synced"}, []string{"testProject", "default"}, "test"), "/api/badge?project=default&project=testProject", "test", "Healthy", "Synced", Green, Green},
-		{createApplications([]string{"Healthy:OutOfSync", "Healthy:Synced"}, []string{"testProject", "default"}, "default"), "/api/badge?project=default&project=testProject", "default", "Healthy", "OutOfSync", Green, Orange},
-		{createApplications([]string{"Degraded:Synced", "Healthy:Synced"}, []string{"testProject", "default"}, "test"), "/api/badge?project=default&project=testProject", "test", "Degraded", "Synced", Red, Green},
-		{createApplications([]string{"Degraded:OutOfSync", "Healthy:OutOfSync"}, []string{"testProject", "default"}, "default"), "/api/badge?project=default&project=testProject", "default", "Degraded", "OutOfSync", Red, Orange},
-		{createApplications([]string{"Unknown:Unknown", "Unknown:Unknown"}, []string{"testProject", "default"}, "default"), "/api/badge?project=", "default", "Unknown", "Unknown", Purple, Purple},
+		{createApplications([]string{"Healthy:Synced", "Healthy:Synced"}, []string{"default", "default"}, "test"),
+			"/api/badge?project=default", "test", "Healthy", "Synced", Green, Green},
+		{createApplications([]string{"Healthy:Synced", "Healthy:OutOfSync"}, []string{"testProject", "testProject"}, "default"),
+			"/api/badge?project=testProject", "default", "Healthy", "OutOfSync", Green, Orange},
+		{createApplications([]string{"Healthy:Synced", "Degraded:Synced"}, []string{"default", "default"}, "test"),
+			"/api/badge?project=default", "test", "Degraded", "Synced", Red, Green},
+		{createApplications([]string{"Healthy:Synced", "Degraded:OutOfSync"}, []string{"testProject", "testProject"}, "default"),
+			"/api/badge?project=testProject", "default", "Degraded", "OutOfSync", Red, Orange},
+		{createApplications([]string{"Healthy:Synced", "Healthy:Synced"}, []string{"testProject", "default"}, "test"),
+			"/api/badge?project=default&project=testProject", "test", "Healthy", "Synced", Green, Green},
+		{createApplications([]string{"Healthy:OutOfSync", "Healthy:Synced"}, []string{"testProject", "default"}, "default"),
+			"/api/badge?project=default&project=testProject", "default", "Healthy", "OutOfSync", Green, Orange},
+		{createApplications([]string{"Degraded:Synced", "Healthy:Synced"}, []string{"testProject", "default"}, "test"),
+			"/api/badge?project=default&project=testProject", "test", "Degraded", "Synced", Red, Green},
+		{createApplications([]string{"Degraded:OutOfSync", "Healthy:OutOfSync"}, []string{"testProject", "default"}, "default"),
+			"/api/badge?project=default&project=testProject", "default", "Degraded", "OutOfSync", Red, Orange},
+		{createApplications([]string{"Unknown:Unknown", "Unknown:Unknown"}, []string{"testProject", "default"}, "default"),
+			"/api/badge?project=", "default", "Unknown", "Unknown", Purple, Purple},
 	}
 	for _, tt := range projectTests {
 		argoCDCm.ObjectMeta.Namespace = tt.namespace

--- a/server/badge/badge_test.go
+++ b/server/badge/badge_test.go
@@ -2,6 +2,7 @@ package badge
 
 import (
 	"context"
+	"image/color"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -49,6 +50,42 @@ var (
 			},
 		},
 	}
+	testApp2 = v1alpha1.Application{
+		ObjectMeta: v1.ObjectMeta{Name: "testApp2", Namespace: "default"},
+		Status: v1alpha1.ApplicationStatus{
+			Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeSynced},
+			Health: v1alpha1.HealthStatus{Status: health.HealthStatusDegraded},
+			OperationState: &v1alpha1.OperationState{
+				SyncResult: &v1alpha1.SyncOperationResult{
+					Revision: "aa29b85",
+				},
+			},
+		},
+	}
+	testApp3 = v1alpha1.Application{
+		ObjectMeta: v1.ObjectMeta{Name: "testApp3", Namespace: "default"},
+		Status: v1alpha1.ApplicationStatus{
+			Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeOutOfSync},
+			Health: v1alpha1.HealthStatus{Status: health.HealthStatusHealthy},
+			OperationState: &v1alpha1.OperationState{
+				SyncResult: &v1alpha1.SyncOperationResult{
+					Revision: "aa29b85",
+				},
+			},
+		},
+	}
+	testApp4 = v1alpha1.Application{
+		ObjectMeta: v1.ObjectMeta{Name: "testApp4", Namespace: "default"},
+		Status: v1alpha1.ApplicationStatus{
+			Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeOutOfSync},
+			Health: v1alpha1.HealthStatus{Status: health.HealthStatusDegraded},
+			OperationState: &v1alpha1.OperationState{
+				SyncResult: &v1alpha1.SyncOperationResult{
+					Revision: "aa29b85",
+				},
+			},
+		},
+	}
 )
 
 func TestHandlerFeatureIsEnabled(t *testing.T) {
@@ -70,6 +107,38 @@ func TestHandlerFeatureIsEnabled(t *testing.T) {
 	assert.NotContains(t, response, "(aa29b85)")
 }
 
+func TestHandlerFeatureProjectIsEnabled(t *testing.T) {
+	projectTests := []struct {
+		testApp     *v1alpha1.Application
+		apiEndPoint string
+		namespace   string
+		health      string
+		status      string
+		healthColor color.RGBA
+		statusColor color.RGBA
+	}{
+		{&testApp, "/api/badge?project=default", "default", "Healthy", "Synced", Green, Green},
+		{&testApp2, "/api/badge?project=default", "default", "Degraded", "Synced", Red, Green},
+		{&testApp3, "/api/badge?project=default", "default", "Healthy", "OutOfSync", Green, Orange},
+		{&testApp4, "/api/badge?project=default", "default", "Degraded", "OutOfSync", Red, Orange},
+	}
+	for _, tt := range projectTests {
+		settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(&argoCDCm, &argoCDSecret), tt.namespace)
+		handler := NewHandler(appclientset.NewSimpleClientset(tt.testApp), settingsMgr, tt.namespace)
+		req, err := http.NewRequest("GET", tt.apiEndPoint, nil)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		assert.NoError(t, err)
+		assert.Equal(t, "private, no-store", rr.Header().Get("Cache-Control"))
+		response := rr.Body.String()
+
+		assert.Equal(t, toRGBString(tt.healthColor), leftRectColorPattern.FindStringSubmatch(response)[1])
+		assert.Equal(t, toRGBString(tt.statusColor), rightRectColorPattern.FindStringSubmatch(response)[1])
+		assert.Equal(t, tt.health, leftTextPattern.FindStringSubmatch(response)[1])
+		assert.Equal(t, tt.status, rightTextPattern.FindStringSubmatch(response)[1])
+
+	}
+}
 func TestHandlerFeatureIsEnabledRevisionIsEnabled(t *testing.T) {
 	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(&argoCDCm, &argoCDSecret), "default")
 	handler := NewHandler(appclientset.NewSimpleClientset(&testApp), settingsMgr, "default")


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

The current implementation only determines the status and health of the application. However, it was recommended that we add a similar flag for the project containing numerous applications.

The API endpoint : Sample URL: http://localhost:8080/api/badge?project=default

| Badge |Application health |Application status|
| :---: | :---: | :---: |
| Synced/Healthy| All applications healthy |All applications Synced |
| OutOfSync/Healthy| All applications healthy |Not all applications synced |
| Synced/Degraded| Not all applications healthy |All applications Synced |
| OutOfSync/Unhealthy| Not all applications healthy |Not all applications Synced |



Example badge:

<img width="544" alt="Screen Shot 2020-09-08 at 10 45 15 AM" src="https://user-images.githubusercontent.com/48808456/92491701-85430c00-f1c0-11ea-9160-bd3be9eee058.png">

Extra Notes:
Issue link :https://github.com/argoproj/argo-cd/issues/4001
